### PR TITLE
fix: allow for #fanout timeout even if lock not yet acquired

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/distributed-callback-queue.js",
   "scripts": {
     "test": "yarn lint && mdep test run",
+    "test:local": "yarn lint && yarn compile && jest __tests__/*.js",
     "pretest": "yarn compile",
     "prepare": "yarn compile",
     "lint": "eslint ./src",

--- a/src/distributed-callback-queue.js
+++ b/src/distributed-callback-queue.js
@@ -228,9 +228,13 @@ class DistributedCallbackQueue {
         jobAbortPromise,
       ]);
 
+      jobAbortReject = undefined;
       jobAbortPromise = undefined;
     } catch (err) {
-      jobAbortPromise = undefined; // finally {} is too late
+      // doing this in finally {} is too late
+      jobAbortReject = undefined;
+      jobAbortPromise = undefined;
+
       if (notLockAcquisitionError(err)) {
         setImmediate(onJobCompleted, err);
         return jobCompletedPromise;


### PR DESCRIPTION
if a redis connection is unavailable, ioredis-lock and its reconnect configuration (etc.) may not have acquired a lock within the timeout period.  ensure that a timeout interrupts and rejects the #fanout even under such conditions

Fixes #4 

your module can't count on how `ioredis` has been configured, so its lock acquisition capacity is effectively a black box.  if it has been configured (by the caller) to keep trying to reconnect to a Redis server that is unavailable, that may take longer than the timeout period

i have annotated the PR with a further explanation in Comments.  i welcome your feedback

PS. i focused this fix on #fanout only.  i would be happy to apply it more broadly, or to a different layer of the code structure, if such a fix is suitable for other convenience methods you've built